### PR TITLE
Fixed regex for dirty player strings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -306,7 +306,7 @@ function playerAJAX(uuid, ign, e, guild = ''){
 
 function addPlayer(ign, e = 0){
     let uuid = '';
-    ign = ign.replace(/§([0-9]|a|b|e|d|f|k|l|m|n|o|r|c)/gm, '');
+    ign = ign.replace(/(§|�)([0-9]|a|b|e|d|f|k|l|m|n|o|r|c)/gm, '');
     console.log(`Adding player: ${ign}`);
     $.ajax({type: 'GET', async: true, url: mojang+ign, success: (data, status) => {
         if (status === 'success'){


### PR DESCRIPTION
In the Abyss Overlay logs, I saw that `�` was also in there (alongside `§`) for dirty strings so I added it to the regex, simple.