### PR TITLE
Disabled Hardware Acceleration

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,6 +7,7 @@ const path = require('path');
 const { exec } = require('child_process');
 
 let win, splash;
+app.disableHardwareAcceleration()
 function createWindow(){
     splash = new BrowserWindow({width: 400, height: 400, transparent: true, frame: false, alwaysOnTop: true, skipTaskbar: true, show: false, webPreferences: {nodeIntegration: true, contextIsolation: false}});
     splash.loadFile('src/splash.html');


### PR DESCRIPTION
Disabling hardware acceleration allows the user to click through the transparent non-button and top bar parts of the overlay

You can see this working [here](https://youtu.be/aNgpcXAw0iU).

Still needs to be tested on other PCs and platforms.