### PR TITLE
Update Mojang API endpoint and improve log file detection for Lunar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "abyss-overlay",
   "productName": "Abyss Overlay",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "The Official Abyss Stats Overlay",
   "homepage": "https://github.com/Chit132/abyss-overlay",
   "main": "main.js",
   "scripts": {
-    "start": "electron .",
+    "start": "npx electron .",
     "build-installer": "electron-builder --win --x64 --ia32",
     "build-installer-dev": "electron-builder --win --x64",
     "build-mac": "electron-builder --mac",

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ const { Cache } = require('./cache.js');
 
 config.delete('players');
 const HY_API = 'https://api.hypixel.net', HY_HEADER = { 'API-Key': config.get('key', '1') };
-const tagsIP = process.env.TAGS_IP, musicIP = process.env.MUSIC_IP, backendIP = process.env.BACKEND_IP, mojang = 'https://api.mojang.com/users/profiles/minecraft/';
+const tagsIP = process.env.TAGS_IP, musicIP = process.env.MUSIC_IP, backendIP = process.env.BACKEND_IP, mojang = "https://api.minecraftservices.com/minecraft/profile/lookup/name/";
 const CACHE_UUID = new Cache();
 const CACHE_STATS = new Cache();
 var players = [], numplayers = 0, goodkey = true, HyThrottle = false, hypixelAPIdown = false, overlayAPIdown = false, backendThrottle = false, overlayBackendDown = false, logpath = '', goodfile = true, currentWindow = '', user = '', useruuid = config.get('uuid', undefined), sent = false, usernick = undefined, winheight = 600, inlobby = true, zoom = 1, gamemode = config.get('settings.gamemode', 0), gmode = config.get('settings.bwgmode', ''), guildlist = false, tagslist = [], guildtag = config.get('settings.gtag', true), startapi = null, starttime = new Date(), music = {session: false, playing: false, looping: false, queue: [], updatetimer: 0, timeratio: [0, 0], songtimer: 0, locked: false, lockwarned: false};
@@ -131,7 +131,7 @@ function verifyUUID(uuid = null) {
     }
 }
 function verifyIGN(ign, $apiElement) {
-    $.ajax({type: 'GET', async: false, url: `https://api.mojang.com/users/profiles/minecraft/${ign}`, headers: HY_HEADER, success: (data) => {
+    $.ajax({type: 'GET', async: false, url: `${mojang}${ign}`, headers: HY_HEADER, success: (data) => {
         user = data.name;
         useruuid = data.id;
         config.set('uuid', useruuid);


### PR DESCRIPTION
The old Mojang API endpoint for converting usernames to UUIDs would occasionally have unexpected behavior. The endpoint string was updated to the newer endpoint that doesn't have the issues.

The Lunar log file path has changed numerous times over the development of the overlay; these changes aim to fix that by finding the most recently modified log file in the `.lunarclient` directory.